### PR TITLE
More cleanup

### DIFF
--- a/examples/channel.rs
+++ b/examples/channel.rs
@@ -1,16 +1,13 @@
 use piped::PipedClient;
-use reqwest::ClientBuilder;
+use reqwest::Client;
+
+const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 
 #[tokio::main]
 async fn main() {
-    let httpclient = ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
-        .build()
-        .unwrap();
+    let httpclient = Client::new();
 
-    let instance = "https://pipedapi.kavin.rocks".to_string();
-
-    let client = PipedClient::new(httpclient, instance);
+    let client = PipedClient::new(&httpclient, INSTANCE);
 
     let channel = client
         .channel_from_id("UCXuqSBlHAE6Xw-yeJA0Tunw".to_string())

--- a/examples/comments.rs
+++ b/examples/comments.rs
@@ -1,16 +1,13 @@
 use piped::PipedClient;
-use reqwest::ClientBuilder;
+use reqwest::Client;
+
+const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 
 #[tokio::main]
 async fn main() {
-    let httpclient = ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
-        .build()
-        .unwrap();
+    let httpclient = Client::new();
 
-    let instance = "https://pipedapi.kavin.rocks".to_string();
-
-    let client = PipedClient::new(httpclient, instance);
+    let client = PipedClient::new(&httpclient, INSTANCE);
 
     let comments = client
         .comments_from_id("__hYx6ZzFbQ".to_string())

--- a/examples/playlist.rs
+++ b/examples/playlist.rs
@@ -1,16 +1,13 @@
 use piped::PipedClient;
-use reqwest::ClientBuilder;
+use reqwest::Client;
+
+const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 
 #[tokio::main]
 async fn main() {
-    let httpclient = ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
-        .build()
-        .unwrap();
+    let httpclient = Client::new();
 
-    let instance = "https://pipedapi.kavin.rocks".to_string();
-
-    let client = PipedClient::new(httpclient, instance);
+    let client = PipedClient::new(&httpclient, INSTANCE);
 
     let playlist = client
         .playlist_from_id("PLQSoWXSpjA38FIQCvwnVNPlGPVA63WTD8".to_string())

--- a/examples/search_suggestions.rs
+++ b/examples/search_suggestions.rs
@@ -7,7 +7,7 @@ const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 async fn main() {
     let httpclient = Client::new();
 
-    let client = PipedClient::new(&httpclient, instance);
+    let client = PipedClient::new(&httpclient, INSTANCE);
 
     let suggestions = client
         .search_suggestions("techlore".to_string())

--- a/examples/search_suggestions.rs
+++ b/examples/search_suggestions.rs
@@ -1,16 +1,13 @@
 use piped::PipedClient;
-use reqwest::ClientBuilder;
+use reqwest::Client;
+
+const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 
 #[tokio::main]
 async fn main() {
-    let httpclient = ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
-        .build()
-        .unwrap();
+    let httpclient = Client::new();
 
-    let instance = "https://pipedapi.kavin.rocks".to_string();
-
-    let client = PipedClient::new(httpclient, instance);
+    let client = PipedClient::new(&httpclient, instance);
 
     let suggestions = client
         .search_suggestions("techlore".to_string())

--- a/examples/trending.rs
+++ b/examples/trending.rs
@@ -1,16 +1,13 @@
 use piped::PipedClient;
-use reqwest::ClientBuilder;
+use reqwest::Client;
+
+const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 
 #[tokio::main]
 async fn main() {
-    let httpclient = ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
-        .build()
-        .unwrap();
+    let httpclient = Client::new();
 
-    let instance = "https://pipedapi.kavin.rocks".to_string();
-
-    let client = PipedClient::new(httpclient, instance);
+    let client = PipedClient::new(&httpclient, INSTANCE);
 
     let streams = client.trending("US".to_string()).await.unwrap();
 

--- a/examples/video.rs
+++ b/examples/video.rs
@@ -1,16 +1,13 @@
 use piped::PipedClient;
-use reqwest::ClientBuilder;
+use reqwest::Client;
+
+const INSTANCE: &'static str = "https://pipedapi.kavin.rocks";
 
 #[tokio::main]
 async fn main() {
-    let httpclient = ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0")
-        .build()
-        .unwrap();
+    let httpclient = Client::new();
 
-    let instance = "https://pipedapi.kavin.rocks".to_string();
-
-    let client = PipedClient::new(httpclient, instance);
+    let client = PipedClient::new(&httpclient, INSTANCE);
 
     let video = client
         .video_from_id("__hYx6ZzFbQ".to_string())

--- a/piped/Cargo.toml
+++ b/piped/Cargo.toml
@@ -12,5 +12,8 @@ version = "0.0.0"
 
 [dependencies]
 reqwest = "^0.11"
+url = "^2.2"
 serde = {version = "^1.0", features = ["derive"]}
 serde_json = "^1.0"
+
+thiserror = "^1.0"

--- a/piped/src/client.rs
+++ b/piped/src/client.rs
@@ -1,13 +1,14 @@
 use reqwest::{Client, Url};
 
-use crate::{Channel, CommentsInfo, Playlist, RelatedStream, StreamsPage, VideoInfo};
+use crate::{Channel, CommentsInfo, Playlist, RelatedStream, Result, StreamsPage, VideoInfo};
 
 pub struct PipedClient {
     pub httpclient: Client,
     pub instance: String,
 }
 
-const USER_AGENT: &'static str = "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0";
+const USER_AGENT: &'static str =
+    "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0";
 
 impl PipedClient {
     pub fn new<S: AsRef<str>>(httpclient: &Client, instance: S) -> PipedClient {
@@ -17,23 +18,25 @@ impl PipedClient {
         }
     }
 
-    pub async fn trending<S: AsRef<str>>(
-        &self,
-        region: S,
-    ) -> Result<Vec<RelatedStream>, Box<dyn std::error::Error>> {
+    pub async fn trending<S: AsRef<str>>(&self, region: S) -> Result<Vec<RelatedStream>> {
         let mut url = Url::parse(format!("{}/trending", &self.instance).as_str())?;
         url.query_pairs_mut().append_pair("region", region.as_ref());
 
-        let resp = &self.httpclient.get(url)
+        let resp = &self
+            .httpclient
+            .get(url)
             .header("User-Agent", USER_AGENT)
-            .send().await?.text().await?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let streams: Vec<RelatedStream> = serde_json::from_str(resp.as_ref())?;
 
         Ok(streams)
     }
 
-    pub async fn channel_from_id<S: AsRef<str>>(&self, id: S) -> Result<Channel, Box<dyn std::error::Error>> {
+    pub async fn channel_from_id<S: AsRef<str>>(&self, id: S) -> Result<Channel> {
         let resp = &self
             .httpclient
             .get(format!("{}/channel/{}", &self.instance, id.as_ref()))
@@ -53,25 +56,28 @@ impl PipedClient {
         id: S,
         nexturl: S,
         nextbody: S,
-    ) -> Result<StreamsPage, Box<dyn std::error::Error>> {
-        let mut url = Url::parse(format!("{}/nextpage/channels/{}", &self.instance, id.as_ref()).as_str())?;
+    ) -> Result<StreamsPage> {
+        let mut url =
+            Url::parse(format!("{}/nextpage/channels/{}", &self.instance, id.as_ref()).as_str())?;
         url.query_pairs_mut()
             .append_pair("url", nexturl.as_ref())
             .append_pair("id", nextbody.as_ref());
 
-        let resp = &self.httpclient.get(url)
+        let resp = &self
+            .httpclient
+            .get(url)
             .header("User-Agent", USER_AGENT)
-            .send().await?.text().await?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let streams: StreamsPage = serde_json::from_str(resp.as_ref())?;
 
         Ok(streams)
     }
 
-    pub async fn playlist_from_id<S: AsRef<str>>(
-        &self,
-        id: S,
-    ) -> Result<Playlist, Box<dyn std::error::Error>> {
+    pub async fn playlist_from_id<S: AsRef<str>>(&self, id: S) -> Result<Playlist> {
         let resp = &self
             .httpclient
             .get(format!("{}/playlists/{}", &self.instance, id.as_ref()))
@@ -91,22 +97,28 @@ impl PipedClient {
         id: S,
         nexturl: S,
         nextbody: S,
-    ) -> Result<StreamsPage, Box<dyn std::error::Error>> {
-        let mut url = Url::parse(format!("{}/nextpage/playlists/{}", &self.instance, id.as_ref()).as_str())?;
+    ) -> Result<StreamsPage> {
+        let mut url =
+            Url::parse(format!("{}/nextpage/playlists/{}", &self.instance, id.as_ref()).as_str())?;
         url.query_pairs_mut()
             .append_pair("url", nexturl.as_ref())
             .append_pair("id", nextbody.as_ref());
 
-        let resp = &self.httpclient.get(url)
+        let resp = &self
+            .httpclient
+            .get(url)
             .header("User-Agent", USER_AGENT)
-            .send().await?.text().await?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let streams: StreamsPage = serde_json::from_str(resp.as_str())?;
 
         Ok(streams)
     }
 
-    pub async fn video_from_id<S: AsRef<str>>(&self, id: S) -> Result<VideoInfo, Box<dyn std::error::Error>> {
+    pub async fn video_from_id<S: AsRef<str>>(&self, id: S) -> Result<VideoInfo> {
         let resp = &self
             .httpclient
             .get(format!("{}/streams/{}", &self.instance, id.as_ref()))
@@ -121,26 +133,25 @@ impl PipedClient {
         Ok(video)
     }
 
-    pub async fn search_suggestions<S: AsRef<str>>(
-        &self,
-        q: S,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    pub async fn search_suggestions<S: AsRef<str>>(&self, q: S) -> Result<Vec<String>> {
         let mut url = Url::parse(format!("{}/suggestions", &self.instance).as_str())?;
         url.query_pairs_mut().append_pair("query", q.as_ref());
 
-        let resp = &self.httpclient.get(url)
+        let resp = &self
+            .httpclient
+            .get(url)
             .header("User-Agent", USER_AGENT)
-            .send().await?.text().await?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let suggestions: Vec<String> = serde_json::from_str(resp.as_ref())?;
 
         Ok(suggestions)
     }
 
-    pub async fn comments_from_id<S: AsRef<str>>(
-        &self,
-        id: S,
-    ) -> Result<CommentsInfo, Box<dyn std::error::Error>> {
+    pub async fn comments_from_id<S: AsRef<str>>(&self, id: S) -> Result<CommentsInfo> {
         let resp = &self
             .httpclient
             .get(format!("{}/comments/{}", &self.instance, id.as_ref()))
@@ -159,13 +170,19 @@ impl PipedClient {
         &self,
         id: S,
         nexturl: S,
-    ) -> Result<CommentsInfo, Box<dyn std::error::Error>> {
-        let mut url = Url::parse(format!("{}/nextpage/comments/{}", &self.instance, id.as_ref()).as_str())?;
+    ) -> Result<CommentsInfo> {
+        let mut url =
+            Url::parse(format!("{}/nextpage/comments/{}", &self.instance, id.as_ref()).as_str())?;
         url.query_pairs_mut().append_pair("url", nexturl.as_ref());
 
-        let resp = &self.httpclient.get(url)
+        let resp = &self
+            .httpclient
+            .get(url)
             .header("User-Agent", USER_AGENT)
-            .send().await?.text().await?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let comments: CommentsInfo = serde_json::from_str(resp.as_ref())?;
 

--- a/piped/src/client.rs
+++ b/piped/src/client.rs
@@ -7,32 +7,37 @@ pub struct PipedClient {
     pub instance: String,
 }
 
+const USER_AGENT: &'static str = "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0";
+
 impl PipedClient {
-    pub fn new(httpclient: Client, instance: String) -> PipedClient {
+    pub fn new<S: AsRef<str>>(httpclient: &Client, instance: S) -> PipedClient {
         PipedClient {
-            httpclient,
-            instance,
+            httpclient: httpclient.clone(),
+            instance: instance.as_ref().to_string(),
         }
     }
 
-    pub async fn trending(
+    pub async fn trending<S: AsRef<str>>(
         &self,
-        region: String,
+        region: S,
     ) -> Result<Vec<RelatedStream>, Box<dyn std::error::Error>> {
         let mut url = Url::parse(format!("{}/trending", &self.instance).as_str())?;
-        url.query_pairs_mut().append_pair("region", region.as_str());
+        url.query_pairs_mut().append_pair("region", region.as_ref());
 
-        let resp = &self.httpclient.get(url).send().await?.text().await?;
+        let resp = &self.httpclient.get(url)
+            .header("User-Agent", USER_AGENT)
+            .send().await?.text().await?;
 
-        let streams: Vec<RelatedStream> = serde_json::from_str(resp.as_str())?;
+        let streams: Vec<RelatedStream> = serde_json::from_str(resp.as_ref())?;
 
         Ok(streams)
     }
 
-    pub async fn channel_from_id(&self, id: String) -> Result<Channel, Box<dyn std::error::Error>> {
+    pub async fn channel_from_id<S: AsRef<str>>(&self, id: S) -> Result<Channel, Box<dyn std::error::Error>> {
         let resp = &self
             .httpclient
-            .get(format!("{}/channel/{}", &self.instance, id))
+            .get(format!("{}/channel/{}", &self.instance, id.as_ref()))
+            .header("User-Agent", USER_AGENT)
             .send()
             .await?
             .text()
@@ -43,63 +48,69 @@ impl PipedClient {
         Ok(channel)
     }
 
-    pub async fn channel_continuation(
+    pub async fn channel_continuation<S: AsRef<str>>(
         &self,
-        id: String,
-        nexturl: String,
-        nextbody: String,
+        id: S,
+        nexturl: S,
+        nextbody: S,
     ) -> Result<StreamsPage, Box<dyn std::error::Error>> {
-        let mut url = Url::parse(format!("{}/nextpage/channels/{}", &self.instance, id).as_str())?;
+        let mut url = Url::parse(format!("{}/nextpage/channels/{}", &self.instance, id.as_ref()).as_str())?;
         url.query_pairs_mut()
-            .append_pair("url", nexturl.as_str())
-            .append_pair("id", nextbody.as_str());
+            .append_pair("url", nexturl.as_ref())
+            .append_pair("id", nextbody.as_ref());
 
-        let resp = &self.httpclient.get(url).send().await?.text().await?;
+        let resp = &self.httpclient.get(url)
+            .header("User-Agent", USER_AGENT)
+            .send().await?.text().await?;
 
-        let streams: StreamsPage = serde_json::from_str(resp.as_str())?;
+        let streams: StreamsPage = serde_json::from_str(resp.as_ref())?;
 
         Ok(streams)
     }
 
-    pub async fn playlist_from_id(
+    pub async fn playlist_from_id<S: AsRef<str>>(
         &self,
-        id: String,
+        id: S,
     ) -> Result<Playlist, Box<dyn std::error::Error>> {
         let resp = &self
             .httpclient
-            .get(format!("{}/playlists/{}", &self.instance, id))
+            .get(format!("{}/playlists/{}", &self.instance, id.as_ref()))
+            .header("User-Agent", USER_AGENT)
             .send()
             .await?
             .text()
             .await?;
 
-        let playlist: Playlist = serde_json::from_str(resp.as_str())?;
+        let playlist: Playlist = serde_json::from_str(resp.as_ref())?;
 
         Ok(playlist)
     }
 
-    pub async fn playlist_continuation(
+    pub async fn playlist_continuation<S: AsRef<str>>(
         &self,
-        id: String,
-        nexturl: String,
-        nextbody: String,
+        id: S,
+        nexturl: S,
+        nextbody: S,
     ) -> Result<StreamsPage, Box<dyn std::error::Error>> {
-        let mut url = Url::parse(format!("{}/nextpage/playlists/{}", &self.instance, id).as_str())?;
+        let mut url = Url::parse(format!("{}/nextpage/playlists/{}", &self.instance, id.as_ref()).as_str())?;
         url.query_pairs_mut()
-            .append_pair("url", nexturl.as_str())
-            .append_pair("id", nextbody.as_str());
+            .append_pair("url", nexturl.as_ref())
+            .append_pair("id", nextbody.as_ref());
 
-        let resp = &self.httpclient.get(url).send().await?.text().await?;
+        let resp = &self.httpclient.get(url)
+            .header("User-Agent", USER_AGENT)
+            .send().await?.text().await?;
 
         let streams: StreamsPage = serde_json::from_str(resp.as_str())?;
 
         Ok(streams)
     }
 
-    pub async fn video_from_id(&self, id: String) -> Result<VideoInfo, Box<dyn std::error::Error>> {
+    pub async fn video_from_id<S: AsRef<str>>(&self, id: S) -> Result<VideoInfo, Box<dyn std::error::Error>> {
         let resp = &self
             .httpclient
-            .get(format!("{}/streams/{}", &self.instance, id))
+            .get(format!("{}/streams/{}", &self.instance, id.as_ref()))
+            .header("User-Agent", USER_AGENT)
             .send()
             .await?
             .text()
@@ -110,48 +121,53 @@ impl PipedClient {
         Ok(video)
     }
 
-    pub async fn search_suggestions(
+    pub async fn search_suggestions<S: AsRef<str>>(
         &self,
-        q: String,
+        q: S,
     ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
         let mut url = Url::parse(format!("{}/suggestions", &self.instance).as_str())?;
-        url.query_pairs_mut().append_pair("query", q.as_str());
+        url.query_pairs_mut().append_pair("query", q.as_ref());
 
-        let resp = &self.httpclient.get(url).send().await?.text().await?;
+        let resp = &self.httpclient.get(url)
+            .header("User-Agent", USER_AGENT)
+            .send().await?.text().await?;
 
-        let suggestions: Vec<String> = serde_json::from_str(resp.as_str())?;
+        let suggestions: Vec<String> = serde_json::from_str(resp.as_ref())?;
 
         Ok(suggestions)
     }
 
-    pub async fn comments_from_id(
+    pub async fn comments_from_id<S: AsRef<str>>(
         &self,
-        id: String,
+        id: S,
     ) -> Result<CommentsInfo, Box<dyn std::error::Error>> {
         let resp = &self
             .httpclient
-            .get(format!("{}/comments/{}", &self.instance, id))
+            .get(format!("{}/comments/{}", &self.instance, id.as_ref()))
+            .header("User-Agent", USER_AGENT)
             .send()
             .await?
             .text()
             .await?;
 
-        let comments: CommentsInfo = serde_json::from_str(resp.as_str())?;
+        let comments: CommentsInfo = serde_json::from_str(resp.as_ref())?;
 
         Ok(comments)
     }
 
-    pub async fn comments_continuation(
+    pub async fn comments_continuation<S: AsRef<str>>(
         &self,
-        id: String,
-        nexturl: String,
+        id: S,
+        nexturl: S,
     ) -> Result<CommentsInfo, Box<dyn std::error::Error>> {
-        let mut url = Url::parse(format!("{}/nextpage/comments/{}", &self.instance, id).as_str())?;
-        url.query_pairs_mut().append_pair("url", nexturl.as_str());
+        let mut url = Url::parse(format!("{}/nextpage/comments/{}", &self.instance, id.as_ref()).as_str())?;
+        url.query_pairs_mut().append_pair("url", nexturl.as_ref());
 
-        let resp = &self.httpclient.get(url).send().await?.text().await?;
+        let resp = &self.httpclient.get(url)
+            .header("User-Agent", USER_AGENT)
+            .send().await?.text().await?;
 
-        let comments: CommentsInfo = serde_json::from_str(resp.as_str())?;
+        let comments: CommentsInfo = serde_json::from_str(resp.as_ref())?;
 
         Ok(comments)
     }

--- a/piped/src/error.rs
+++ b/piped/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("{0}")]
+    Network(#[from] reqwest::Error),
+    #[error("{0}")]
+    ParseResponse(#[from] serde_json::error::Error),
+    #[error("{0}")]
+    Parseurl(#[from] url::ParseError),
+}

--- a/piped/src/lib.rs
+++ b/piped/src/lib.rs
@@ -1,5 +1,7 @@
 mod client;
+mod error;
 mod structure;
 
 pub use client::PipedClient;
+pub use error::{Error, Result};
 pub use structure::*;


### PR DESCRIPTION
- Make functions take references instead of `Client`, `String`.
- Moved `User-Agent` into the library as the use of a User-Agent is currently undocumented (can be reverted if you do not want that).